### PR TITLE
:newspaper: Add tests and LICENSE to sdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ sudo: false
 language: python
 python:
   - pypy
-  - 3.7-dev
+  - 3.8
+  - 3.7
   - 3.6
   - 3.5
-  - 3.4
   - 2.7
 notifications:
   email: false

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,9 @@
+include LICENSE
 include README.rst
 include CONTRIBUTORS.rst
 include CHANGELOG.rst
 recursive-include yehua/resources *
+recursive-include tests *.py
+recursive-include tests *.txt
+recursive-include tests *.yml
+recursive-include tests Makefile

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ INSTALL_REQUIRES = [
 SETUP_COMMANDS = {}
 
 
-PACKAGES = find_packages(exclude=["ez_setup", "examples", "tests"])
+PACKAGES = find_packages(exclude=["ez_setup", "examples", "tests", "tests.*"])
 EXTRAS_REQUIRE = {
 }
 # You do not need to read beyond this line


### PR DESCRIPTION
Also exclude `tests.*` from the runtime installation.

Fixes https://github.com/moremoban/yehua/issues/27